### PR TITLE
Supineのハンドジェスチャー足固定をアバターのWrite Defaults設定に合わせる

### DIFF
--- a/Packages/jp.unisakistudio.kawaiiposing/他商品連携用Prefabs/ごろ寝システムEX.prefab
+++ b/Packages/jp.unisakistudio.kawaiiposing/他商品連携用Prefabs/ごろ寝システムEX.prefab
@@ -1368,7 +1368,7 @@ MonoBehaviour:
   layerType: 5
   deleteAttachedAnimator: 0
   pathMode: 0
-  matchAvatarWriteDefaults: 0
+  matchAvatarWriteDefaults: 1
   relativePathRoot:
     referencePath: 
     targetObject: {fileID: 0}


### PR DESCRIPTION
Fixes #3

<img width="596" height="480" alt="Screenshot 2026-01-05 at 22 09 33" src="https://github.com/user-attachments/assets/4b9bb0c4-666f-4e48-950e-f68bf566a747" />